### PR TITLE
Change paper-item focused bg color and selected appearance

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/PolymerElements/paper-menu",
   "ignore": [],
   "dependencies": {
-    "iron-menu-behavior": "PolymerElements/iron-menu-behavior#^0.9.0",
+    "iron-menu-behavior": "PolymerElements/iron-menu-behavior#^0.9.2",
     "paper-styles": "PolymerElements/paper-styles#^0.9.0",
     "polymer": "Polymer/polymer#^0.9.0"
   },

--- a/paper-menu.html
+++ b/paper-menu.html
@@ -27,7 +27,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       background: var(--paper-menu-background-color, --primary-background-color);
       color: var(--paper-menu-color, --primary-text-color);
 
-      mixin(--paper-menu);
+      @apply(--paper-menu);
     }
 
     :host > ::content > [disabled] {
@@ -46,13 +46,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       opacity: 0.12;
       content: '';
 
-      mixin(--paper-menu-selected-item);
+      @apply(--paper-menu-selected-item);
     }
 
     :host > ::content > .iron-selected[colored]::after {
       opacity: 0.26;
 
-      mixin(--paper-menu-colored-selected-item);
+      @apply(--paper-menu-colored-selected-item);
     }
 
   </style>

--- a/paper-menu.html
+++ b/paper-menu.html
@@ -34,27 +34,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       color: var(--paper-menu-disabled-color, --disabled-text-color);
     }
 
-    :host > ::content > .iron-selected {
+    :host > ::content > *:focus {
       position: relative;
+      outline: 0;
     }
 
-    :host > ::content > .iron-selected::after {
+    :host > ::content > *:focus:after {
       @apply(--layout-fit);
-
       background: currentColor;
       /* FIXME move to paper-styles for next widget */
       opacity: 0.12;
       content: '';
 
-      @apply(--paper-menu-selected-item);
+      @apply(--paper-menu-focused-item);
     }
 
-    :host > ::content > .iron-selected[colored]::after {
+    :host > ::content > *[colored]:focus:after {
       opacity: 0.26;
 
-      @apply(--paper-menu-colored-selected-item);
+      @apply(--paper-menu-colored-focused-item);
     }
 
+    :host > ::content > .iron-selected {
+      font-weight: bold;
+
+      @apply(--paper-menu-selected-item);
+    }
   </style>
 
   <template>

--- a/test/paper-menu.html
+++ b/test/paper-menu.html
@@ -40,12 +40,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script>
 
-      suite('basic', function() {
+      suite('<paper-menu>', function() {
+        var menu;
+
+        setup(function() {
+          menu = fixture('basic');
+        });
 
         test('selected item is styled', function() {
-          var menu = fixture('basic');
+
+          var boldDiv = document.createElement('div');
+          boldDiv.style.fontWeight = 'bold';
+          document.body.appendChild(boldDiv);
+
           menu.selected = 1;
-          assert.notEqual(getComputedStyle(menu.selectedItem, '::after').background, getComputedStyle(menu.selectedItem).background, 'selected item is highlighted');
+
+          assert.equal(getComputedStyle(menu.selectedItem).fontWeight, 
+              getComputedStyle(boldDiv).fontWeight, 'selected item is bold');
         });
 
       });


### PR DESCRIPTION
**Material design spec audit - few changes needed  https://github.com/PolymerElements/paper-menu/issues/11**
- Set background color for focused items and make them bold if selected.

cc @morethanreal @cdata @notwaldorf  
