### PR TITLE
Changing dynamic elements results in strange `selected` attribute behavior

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -26,7 +26,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       WCT.loadSuites([
         'paper-menu.html',
-        'paper-submenu.html'
+        'paper-submenu.html',
+        'paper-menu-repeat.html',
       ]);
 
     </script>

--- a/test/paper-menu-repeat.html
+++ b/test/paper-menu-repeat.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+  <head>
+
+    <title>paper-menu with repeat dom template</title>
+
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+
+    <script src="../../web-component-tester/browser.js"></script>
+    <script src="../../iron-test-helpers/mock-interactions.js"></script>
+
+    <link rel="import" href="../paper-menu.html">
+
+  </head>
+  <body>
+    
+    <template is="dom-bind" id="menu-test-dom-bind">
+      <paper-menu id="menu" selected="item 1">
+        <template is="dom-repeat" items="[[items]]" attr-for-selected="id">
+          <div id="[[item.name]]">[[item.name]]</div>
+        </template>
+      </paper-menu>
+    </template>
+
+    <script>
+
+      suite('<paper-menu>', function() {
+        var menu, domBindTemplate;
+
+        setup(function() {
+          domBindTemplate = document.getElementById('menu-test-dom-bind');
+          domBindTemplate.items = [{name: 'item 1'}, {name: 'item 2'}, {name: 'item 3'}, {name: 'item 4'}];
+          menu = domBindTemplate.$.menu;
+        });
+        
+        test('supports dynamic items', function(done) {
+          domBindTemplate.items = [{name: 'item A'}, {name: 'item B'}];
+          setTimeout(function () {
+            assert.equal(menu.items.length, 2);
+            // The value is kept from the previous array of elements
+            assert.equal(menu.selected, 'item 1');
+            // Tap the 2nd item
+            MockInteractions.tap(menu.items[1]);
+            // The selected value should change
+            assert.equal(menu.selected, 'item B');
+            done();
+          });
+        });
+
+      });
+
+    </script>
+
+  </body>
+</html>


### PR DESCRIPTION
This is happening when the we combine the `attr-for-selected` property with dynamic items.

I was getting this behavior in a higher level element: [paper-dropdown-menu](https://github.com/PolymerElements/paper-dropdown-menu) and I think I have narrowed it down to this element, though it can be any of the behaviors in iron-selector, however I wasn't able to reproduce there.

I have created a test that fails. I'd also like to get feedback on the test (naming, methods used, etc) so I can improve it and make it easier for someone else to jump in and fix the bug.

The result of this test is:

![image](https://cloud.githubusercontent.com/assets/570771/9429629/fa034d62-49d6-11e5-8a69-148496048233.png)
