### PR TITLE
fix-submenu-tests

### DIFF
--- a/test/paper-submenu.html
+++ b/test/paper-submenu.html
@@ -29,6 +29,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <link rel="import" href="../paper-submenu.html">
 
   </head>
+  <style>
+    paper-item {
+      font-weight: normal;
+    }
+  </style>
   <body>
 
     <test-fixture id="basic">


### PR DESCRIPTION
Fixed #63. For some reason, the items are all initially bolded in the test (when inspecting, they all look bolded by default, so it makes sense the test fails. I don't know how long this test has been broken, but this style fixes it. :/
