### PR TITLE
Fixes #27, #31, #41: Prevent :after element from blocking click event in Safari / Firefox.

### DIFF
--- a/paper-menu-shared-styles.html
+++ b/paper-menu-shared-styles.html
@@ -34,6 +34,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         background: currentColor;
         opacity: var(--dark-divider-opacity);
         content: '';
+        pointer-events: none;
 
         @apply(--paper-menu-focused-item-after);
       }


### PR DESCRIPTION
This is the same problem as PolymerElements/paper-behaviors#34, but `paper-menu` has its own implementation of the same `:after`-based highlight which also needs to be updated.
