### PR TITLE
Polymer v2 preparations

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -96,18 +96,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <div class="horizontal-section">
         <paper-menu attr-for-item-title="label" multi>
           <paper-submenu label="paper-menu">
-            <paper-item class="menu-trigger">paper-menu</paper-item>
-            <paper-menu class="menu-content sublist" multi>
+            <paper-item slot="menu-trigger" class="menu-trigger">paper-menu</paper-item>
+            <paper-menu slot="menu-content" class="menu-content sublist" multi>
               <paper-submenu label="Properties">
-                <paper-item class="menu-trigger">Properties</paper-item>
-                <paper-menu class="menu-content sublist2">
+                <paper-item slot="menu-trigger" class="menu-trigger">Properties</paper-item>
+                <paper-menu slot="menu-content" class="menu-content sublist2">
                   <paper-item>focusedItem</paper-item>
                   <paper-item>attrForItemTitle</paper-item>
                 </paper-menu>
               </paper-submenu>
               <paper-submenu label="Methods">
-                <paper-item class="menu-trigger">Methods</paper-item>
-                <paper-menu class="menu-content sublist2">
+                <paper-item slot="menu-trigger" class="menu-trigger">Methods</paper-item>
+                <paper-menu slot="menu-content" class="menu-content sublist2">
                   <paper-item>select(value)</paper-item>
                 </paper-menu>
               </paper-submenu>
@@ -115,17 +115,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         </paper-submenu>
 
         <paper-submenu label="paper-submenu">
-          <paper-item class="menu-trigger">paper-submenu</paper-item>
-          <paper-menu class="menu-content sublist">
+          <paper-item slot="menu-trigger" class="menu-trigger">paper-submenu</paper-item>
+          <paper-menu slot="menu-content" class="menu-content sublist">
             <paper-submenu label="Properties">
-              <paper-item class="menu-trigger">Properties</paper-item>
-              <paper-menu class="menu-content sublist2">
+              <paper-item slot="menu-trigger" class="menu-trigger">Properties</paper-item>
+              <paper-menu slot="menu-content" class="menu-content sublist2">
                 <paper-item>opened</paper-item>
               </paper-menu>
               </paper-submenu>
               <paper-submenu label="Methods">
-                <paper-item class="menu-trigger">Methods</paper-item>
-                <paper-menu class="menu-content sublist2">
+                <paper-item slot="menu-trigger" class="menu-trigger">Methods</paper-item>
+                <paper-menu slot="menu-content" class="menu-content sublist2">
                   <paper-item>open()</paper-item>
                   <paper-item>close()</paper-item>
                   <paper-item>toggle()</paper-item>
@@ -135,8 +135,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         </paper-submenu>
 
           <paper-submenu label="Unavailable" disabled>
-            <paper-item class="menu-trigger">Unavailable</paper-item>
-            <paper-menu class="menu-content sublist">
+            <paper-item slot="menu-trigger" class="menu-trigger">Unavailable</paper-item>
+            <paper-menu slot="menu-content" class="menu-content sublist">
               <paper-item>Unavailable 1</paper-item>
               <paper-item>Unavailable 2</paper-item>
             </paper-menu>

--- a/paper-menu-shared-styles.html
+++ b/paper-menu-shared-styles.html
@@ -19,28 +19,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       .selectable-content > ::content > .iron-selected {
         font-weight: bold;
 
-        @apply(--paper-menu-selected-item);
+        @apply --paper-menu-selected-item;
       }
 
       .selectable-content > ::content > [disabled] {
-        color: var(--paper-menu-disabled-color, --disabled-text-color);
+        color: var(--paper-menu-disabled-color, var(--disabled-text-color));
       }
 
       .selectable-content > ::content > *:focus {
         position: relative;
         outline: 0;
 
-        @apply(--paper-menu-focused-item);
+        @apply --paper-menu-focused-item;
       }
 
       .selectable-content > ::content > *:focus:after {
-        @apply(--layout-fit);
+        @apply --layout-fit;
         background: currentColor;
         opacity: var(--dark-divider-opacity);
         content: '';
         pointer-events: none;
 
-        @apply(--paper-menu-focused-item-after);
+        @apply --paper-menu-focused-item-after;
       }
 
       .selectable-content > ::content > *[colored]:focus:after {

--- a/paper-menu.html
+++ b/paper-menu.html
@@ -74,15 +74,15 @@ of a menu item will also focus it.
         display: block;
         padding: 8px 0;
 
-        background: var(--paper-menu-background-color, --primary-background-color);
-        color: var(--paper-menu-color, --primary-text-color);
+        background: var(--paper-menu-background-color, var(--primary-background-color));
+        color: var(--paper-menu-color, var(--primary-text-color));
 
-        @apply(--paper-menu);
+        @apply --paper-menu;
       }
     </style>
 
     <div class="selectable-content">
-      <content></content>
+      <slot></slot>
     </div>
   </template>
 

--- a/paper-submenu.html
+++ b/paper-submenu.html
@@ -19,23 +19,23 @@ consists of a trigger that expands or collapses another `<paper-menu>`:
 
     <paper-menu>
       <paper-submenu>
-        <paper-item class="menu-trigger">Topics</paper-item>
-        <paper-menu class="menu-content">
+        <paper-item slot="menu-trigger">Topics</paper-item>
+        <paper-menu slot="menu-content">
           <paper-item>Topic 1</paper-item>
           <paper-item>Topic 2</paper-item>
           <paper-item>Topic 3</paper-item>
         </paper-menu>
       </paper-submenu>
       <paper-submenu>
-        <paper-item class="menu-trigger">Faves</paper-item>
-        <paper-menu class="menu-content">
+        <paper-item slot="menu-trigger">Faves</paper-item>
+        <paper-menu slot="menu-content">
           <paper-item>Fave 1</paper-item>
           <paper-item>Fave 2</paper-item>
         </paper-menu>
       </paper-submenu>
       <paper-submenu disabled>
-        <paper-item class="menu-trigger">Unavailable</paper-item>
-        <paper-menu class="menu-content">
+        <paper-item slot="menu-trigger">Unavailable</paper-item>
+        <paper-menu slot="menu-content">
           <paper-item>Disabled 1</paper-item>
           <paper-item>Disabled 2</paper-item>
         </paper-menu>
@@ -58,10 +58,10 @@ item has bolded text. Please see the `<paper-menu>` docs for which attributes
     <style include="paper-menu-shared-styles"></style>
 
     <div class="selectable-content" on-tap="_onTap">
-      <content id="trigger" select=".menu-trigger"></content>
+      <slot id="trigger" name="menu-trigger"></slot>
     </div>
     <iron-collapse id="collapse" opened="{{opened}}">
-      <content id="content" select=".menu-content"></content>
+      <slot id="content" name="menu-content"></slot>
     </iron-collapse>
   </template>
 

--- a/test/paper-submenu.html
+++ b/test/paper-submenu.html
@@ -38,24 +38,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <template>
         <paper-menu>
           <paper-submenu>
-            <paper-item slot="menu-trigger">Topic 1</paper-item>
-            <paper-menu slot="menu-content">
+            <paper-item slot="menu-trigger" class="menu-trigger">Topic 1</paper-item>
+            <paper-menu slot="menu-content" class="menu-content">
               <paper-item>item 1.1</paper-item>
               <paper-item>item 1.2</paper-item>
               <paper-item>item 1.3</paper-item>
             </paper-menu>
           </paper-submenu>
           <paper-submenu>
-            <paper-item slot="menu-trigger">Topic 2</paper-item>
-            <paper-menu slot="menu-content">
+            <paper-item slot="menu-trigger" class="menu-trigger">Topic 2</paper-item>
+            <paper-menu slot="menu-content" class="menu-content">
               <paper-item>item 2.1</paper-item>
               <paper-item>item 2.2</paper-item>
               <paper-item>item 2.3</paper-item>
             </paper-menu>
           </paper-submenu>
           <paper-submenu disabled>
-            <paper-item slot="menu-trigger">Topic 3</paper-item>
-            <paper-menu slot="menu-content">
+            <paper-item slot="menu-trigger" class="menu-trigger">Topic 3</paper-item>
+            <paper-menu slot="menu-content" class="menu-content">
               <paper-item>item 3.1</paper-item>
               <paper-item>item 3.2</paper-item>
               <paper-item>item 3.3</paper-item>
@@ -69,8 +69,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <template>
         <paper-menu>
           <paper-submenu class="menu-content" opened>
-            <paper-item slot="menu-trigger">My submenu is opened to start!</paper-item>
-            <paper-menu slot="menu-content">
+            <paper-item slot="menu-trigger" class="menu-trigger">My submenu is opened to start!</paper-item>
+            <paper-menu slot="menu-content" class="menu-content">
               <paper-item>Triggered item</paper-item>
             </paper-menu>
           </paper-submenu>

--- a/test/paper-submenu.html
+++ b/test/paper-submenu.html
@@ -38,24 +38,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <template>
         <paper-menu>
           <paper-submenu>
-            <paper-item class="menu-trigger">Topic 1</paper-item>
-            <paper-menu class="menu-content">
+            <paper-item slot="menu-trigger">Topic 1</paper-item>
+            <paper-menu slot="menu-content">
               <paper-item>item 1.1</paper-item>
               <paper-item>item 1.2</paper-item>
               <paper-item>item 1.3</paper-item>
             </paper-menu>
           </paper-submenu>
           <paper-submenu>
-            <paper-item class="menu-trigger">Topic 2</paper-item>
-            <paper-menu class="menu-content">
+            <paper-item slot="menu-trigger">Topic 2</paper-item>
+            <paper-menu slot="menu-content">
               <paper-item>item 2.1</paper-item>
               <paper-item>item 2.2</paper-item>
               <paper-item>item 2.3</paper-item>
             </paper-menu>
           </paper-submenu>
           <paper-submenu disabled>
-            <paper-item class="menu-trigger">Topic 3</paper-item>
-            <paper-menu class="menu-content">
+            <paper-item slot="menu-trigger">Topic 3</paper-item>
+            <paper-menu slot="menu-content">
               <paper-item>item 3.1</paper-item>
               <paper-item>item 3.2</paper-item>
               <paper-item>item 3.3</paper-item>
@@ -69,8 +69,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <template>
         <paper-menu>
           <paper-submenu class="menu-content" opened>
-            <paper-item class="menu-trigger">My submenu is opened to start!</paper-item>
-            <paper-menu class="menu-content">
+            <paper-item slot="menu-trigger">My submenu is opened to start!</paper-item>
+            <paper-menu slot="menu-content">
               <paper-item>Triggered item</paper-item>
             </paper-menu>
           </paper-submenu>


### PR DESCRIPTION
Hi.

We are trying to migrate to Polymer v2 and the only component we use that isn't at version 2 is this one.

So I thought I might give it a try to upgrade this one to some sort of hybrid version. I looked at paper-item as an example and the only changes I saw were done on it was to use slot instead of content notation. And how you use CSS variables and apply logic.

I'm not sure if this is all the changes that are needed but I hope it helps to migrate this to v2.

And if changes are needed I'm willing to work to this end.

Best regards
Daniel